### PR TITLE
Update producttooltip.php

### DIFF
--- a/producttooltip.php
+++ b/producttooltip.php
@@ -164,7 +164,7 @@ class ProductToolTip extends Module
 					array(
 						'type' => 'switch',
 						'label' => $this->l('Number of visitors'),
-						'desc' => $this->l('Display the number of visitors who are currently watching this product?').'<br>'.
+						'desc' => $this->l('Display the number of visitors who are currently watching this product.').'<br>'.
 							$this->l('If you activate the option above, you must activate the first option ("Save page views for each customer") of the "Data mining for statistics" (StatsData) module.'),
 						'name' => 'PS_PTOOLTIP_PEOPLE',
 						'values' => array(
@@ -203,7 +203,7 @@ class ProductToolTip extends Module
 					array(
 						'type' => 'switch',
 						'label' => $this->l('Last order date'),
-						'desc' => $this->l('Display the last time the product has been ordered?'),
+						'desc' => $this->l('Display the last time the product has been ordered'),
 						'name' => 'PS_PTOOLTIP_DATE_ORDER',
 						'values' => array(
 							array(
@@ -221,7 +221,7 @@ class ProductToolTip extends Module
 					array(
 						'type' => 'switch',
 						'label' => $this->l('Added to a cart'),
-						'desc' => $this->l('If the product has not been ordered yet, display the last time the product has been added to a cart?'),
+						'desc' => $this->l('If the product has not been ordered yet, display the last time the product has been added to a cart.'),
 						'name' => 'PS_PTOOLTIP_DATE_CART',
 						'values' => array(
 							array(


### PR DESCRIPTION
The question marks in the explanations don't make any sense and should be dropped or changed to just a period, especially when you consider the translation into other languages.
